### PR TITLE
Use Arch on Travis instead of Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,36 @@
-language: cpp
-
-notifications:
-  email: false
+sudo: required
 
 branches:
   only:
     - master
 
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-7', 'gcc-7']
-      env:
-        - MODULES=On
-        - CXX_COMPILER=clang++-5.0
-        - COMPILER=clang-5.0
+language: c++
 
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-7', 'gcc-7']
-      env:
-        - MODULES=Off
-        - CXX_COMPILER=clang++-5.0
-        - COMPILER=clang-5.0
+compiler:
+  - gcc
+  - clang
+
+notifications:
+  email: false
+
+arch:
+  packages:
+    - cmake
+    - clang
+    - clang-tools-extra
+    - llvm-libs
+    - llvm
+    - valgrind
+  - env:
+    - MODULES=On
+    - CXX_COMPILER=clang++-5.0
+    - COMPILER=clang-5.0
+  - env:
+    - MODULES=Off
+    - CXX_COMPILER=clang++-5.0
+    - COMPILER=clang-5.0
+  script:
+    - ./scripts/run_travis.sh $COMPILER $CXX_COMPILER $MODULES
 
 script:
-  - ./scripts/run_travis.sh $COMPILER $CXX_COMPILER $MODULES
+  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ notifications:
   email: false
 
 env:
-  - MODULES=On CXX_COMPILER=clang++-5.0 COMPILER=clang-5.0
-  - MODULES=Off CXX_COMPILER=clang++-5.0 COMPILER=clang-5.0
+  - MODULES=On CXX_COMPILER=clang++ COMPILER=clang
+  - MODULES=Off CXX_COMPILER=clang++ COMPILER=clang
 
 arch:
   packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0', 'ppa:jonathonf/gcc-7.1']
+          packages: ['clang-5.0', 'g++-7', 'gcc-7']
       env:
         - MODULES=On
         - CXX_COMPILER=clang++-5.0
@@ -26,8 +26,8 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0', 'ppa:jonathonf/gcc-7.1']
+          packages: ['clang-5.0', 'g++-7', 'gcc-7']
       env:
         - MODULES=Off
         - CXX_COMPILER=clang++-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
 language: c++
 
 compiler:
-  - gcc
   - clang
 
 notifications:
@@ -20,7 +19,6 @@ arch:
     - clang-tools-extra
     - llvm-libs
     - llvm
-    - valgrind
   env:
     - MODULES=On
     - CXX_COMPILER=clang++-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ compiler:
 notifications:
   email: false
 
+env:
+  - MODULES=On
+  - CXX_COMPILER=clang++-5.0
+  - COMPILER=clang-5.0
+
 arch:
   packages:
     - cmake
@@ -19,10 +24,6 @@ arch:
     - clang-tools-extra
     - llvm-libs
     - llvm
-  env:
-    - MODULES=On
-    - CXX_COMPILER=clang++-5.0
-    - COMPILER=clang-5.0
   script:
     - ./scripts/run_travis.sh $COMPILER $CXX_COMPILER $MODULES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ arch:
     - clang-tools-extra
     - llvm-libs
     - llvm
+    - python
+    - python3
   script:
     - ./scripts/run_travis.sh $COMPILER $CXX_COMPILER $MODULES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ notifications:
   email: false
 
 env:
-  - MODULES=On
-  - CXX_COMPILER=clang++-5.0
-  - COMPILER=clang-5.0
+  - MODULES=On CXX_COMPILER=clang++-5.0 COMPILER=clang-5.0
+  - MODULES=Off CXX_COMPILER=clang++-5.0 COMPILER=clang-5.0
 
 arch:
   packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,8 @@ arch:
     - llvm-libs
     - llvm
     - valgrind
-  - env:
+  env:
     - MODULES=On
-    - CXX_COMPILER=clang++-5.0
-    - COMPILER=clang-5.0
-  - env:
-    - MODULES=Off
     - CXX_COMPILER=clang++-5.0
     - COMPILER=clang-5.0
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-6']
+          packages: ['clang-5.0', 'g++-7', 'gcc-7']
       env:
         - MODULES=On
         - CXX_COMPILER=clang++-5.0
@@ -27,7 +27,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-6']
+          packages: ['clang-5.0', 'g++-7', 'gcc-7']
       env:
         - MODULES=Off
         - CXX_COMPILER=clang++-5.0


### PR DESCRIPTION
Because it provides newest version of packages, and actually fix two errors.