### PR TITLE
[boost-patch] Remove utility include

### DIFF
--- a/inc/boost/graph/iteration_macros.hpp
+++ b/inc/boost/graph/iteration_macros.hpp
@@ -10,8 +10,6 @@
 #ifndef BOOST_GRAPH_ITERATION_MACROS_HPP
 #define BOOST_GRAPH_ITERATION_MACROS_HPP
 
-#include <utility>
-
 #define BGL_CAT(x,y) x ## y
 #define BGL_RANGE(linenum) BGL_CAT(bgl_range_,linenum)
 #define BGL_FIRST(linenum) (BGL_RANGE(linenum).first)


### PR DESCRIPTION
This header is included inside classes/namespaces, so it can't
just include utility. This works in boost because every including
header already includes <utility> (so the header guards rescue us
from redefining the <utility> contents inside this header), but in the modules
case we actually try to include it and we get the clang error:

/home/travis/build/Teemperor/boost-compile/inc/boost/graph/iteration_macros.hpp:13:1: /home/travis/build/Teemperor/boost-compile/inc/boost/graph/iteration_macros.hpp:13:1: /home/travis/build/Teemperor/boost-compile/inc/boost/graph/iteration_macros.hpp:13:1: /home/travis/build/Teemperor/boost-compile/inc/boost/graph/iteration_macros.hpp:13:1: error:
      redundant #include of module 'stl14.utility' appears within namespace
      'boost' [-Wmodules-import-nested-redundant]
 include <utility>
^