### PR TITLE
Add check_header.rb

### DIFF
--- a/check_header.rb
+++ b/check_header.rb
@@ -1,0 +1,10 @@
+#! /usr/bin/ruby
+
+File.open(ARGV[0], "r").read.each_line do |line|
+  prefix = "boost-compile/inc/boost/"
+  if line =~ %r(#{prefix}(.*?)$)
+    if File.readlines("inc/boost/module.modulemap").grep($1).size == 0
+      p $1
+    end
+  end
+end


### PR DESCRIPTION
You can see the list of headers in output but not in modulemap by`ruby check_header.rb <output file of "./scripts/run_travis.sh clang clang++ print">`